### PR TITLE
Implement Admin Mode with Teacher Authentication (Closes #5)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -153,6 +153,7 @@ def auth_status(session_id: Optional[str] = Cookie(None)):
         return {"authenticated": False}
 
 
+@app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,15 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Cookie
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, JSONResponse
+from pydantic import BaseModel
 import os
 from pathlib import Path
+import json
+import uuid
+from typing import Optional
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +22,17 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials from JSON file
+def load_teachers():
+    teachers_file = Path(__file__).parent / "teachers.json"
+    with open(teachers_file, "r") as f:
+        return json.load(f)
+
+teachers = load_teachers()
+
+# In-memory session storage: session_id -> teacher_username
+authenticated_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -78,7 +93,66 @@ activities = {
 }
 
 
-@app.get("/")
+# Pydantic models for request bodies
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+# Helper function to verify teacher credentials
+def verify_teacher(username: str, password: str) -> bool:
+    """Verify if the provided credentials match any teacher"""
+    for teacher in teachers["teachers"]:
+        if teacher["username"] == username and teacher["password"] == password:
+            return True
+    return False
+
+
+# Helper function to check if a session is authenticated
+def get_authenticated_user(session_id: Optional[str]) -> Optional[str]:
+    """Returns the username if session is valid, None otherwise"""
+    return authenticated_sessions.get(session_id)
+
+
+@app.post("/auth/login")
+def login(request: LoginRequest):
+    """Authenticate a teacher and create a session"""
+    if not verify_teacher(request.username, request.password):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    
+    # Create a new session
+    session_id = str(uuid.uuid4())
+    authenticated_sessions[session_id] = request.username
+    
+    response = JSONResponse(
+        {"message": f"Logged in as {request.username}"},
+        status_code=200
+    )
+    response.set_cookie("session_id", session_id, httponly=True, samesite="lax")
+    return response
+
+
+@app.post("/auth/logout")
+def logout(session_id: Optional[str] = Cookie(None)):
+    """Logout a teacher and invalidate session"""
+    if session_id and session_id in authenticated_sessions:
+        del authenticated_sessions[session_id]
+    
+    response = JSONResponse({"message": "Logged out successfully"})
+    response.delete_cookie("session_id")
+    return response
+
+
+@app.get("/auth/status")
+def auth_status(session_id: Optional[str] = Cookie(None)):
+    """Check if user is authenticated"""
+    user = get_authenticated_user(session_id)
+    if user:
+        return {"authenticated": True, "username": user}
+    else:
+        return {"authenticated": False}
+
+
 def root():
     return RedirectResponse(url="/static/index.html")
 
@@ -89,8 +163,13 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, session_id: Optional[str] = Cookie(None)):
+    """Sign up a student for an activity (teachers only)"""
+    # Check authentication
+    user = get_authenticated_user(session_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="Not authenticated. Only teachers can register students.")
+    
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +190,13 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, session_id: Optional[str] = Cookie(None)):
+    """Unregister a student from an activity (teachers only)"""
+    # Check authentication
+    user = get_authenticated_user(session_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="Not authenticated. Only teachers can unregister students.")
+    
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -130,3 +214,4 @@ def unregister_from_activity(activity_name: str, email: str):
     # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}
+

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -2,7 +2,139 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
+  const signupContainer = document.getElementById("signup-container");
   const messageDiv = document.getElementById("message");
+  const userBtn = document.getElementById("user-btn");
+  const userMenu = document.getElementById("user-menu");
+  const userInfo = document.getElementById("user-info");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loginModal = document.getElementById("login-modal");
+  const closeBtn = document.querySelector(".close-btn");
+  const loginForm = document.getElementById("login-form");
+  const loginMessage = document.getElementById("login-message");
+
+  let isAuthenticated = false;
+  let currentUser = null;
+
+  // Check authentication status on page load
+  async function checkAuthStatus() {
+    try {
+      const response = await fetch("/auth/status");
+      const data = await response.json();
+      isAuthenticated = data.authenticated;
+      currentUser = data.username;
+      updateUI();
+      fetchActivities();
+    } catch (error) {
+      console.error("Error checking auth status:", error);
+      fetchActivities();
+    }
+  }
+
+  // Update UI based on authentication status
+  function updateUI() {
+    if (isAuthenticated) {
+      userBtn.textContent = `👤 ${currentUser}`;
+      userInfo.innerHTML = `<p>Logged in as: <strong>${currentUser}</strong></p>`;
+      logoutBtn.classList.remove("hidden");
+      signupContainer.classList.remove("hidden");
+    } else {
+      userBtn.textContent = "👤 Login";
+      userInfo.innerHTML = "";
+      logoutBtn.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+    }
+    // Refresh activities to show/hide delete buttons
+    fetchActivities();
+  }
+
+  // Toggle user menu
+  userBtn.addEventListener("click", () => {
+    userMenu.classList.toggle("hidden");
+  });
+
+  // Close user menu when clicking outside
+  document.addEventListener("click", (e) => {
+    if (!e.target.closest(".user-section")) {
+      userMenu.classList.add("hidden");
+    }
+  });
+
+  // Open login modal when not authenticated
+  userBtn.addEventListener("dblclick", () => {
+    if (!isAuthenticated) {
+      loginModal.classList.remove("hidden");
+    }
+  });
+
+  // Close modal when clicking close button
+  closeBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginMessage.classList.add("hidden");
+  });
+
+  // Close modal when clicking outside
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) {
+      loginModal.classList.add("hidden");
+    }
+  });
+
+  // Handle login form submission
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        loginMessage.textContent = result.message;
+        loginMessage.className = "success";
+        loginMessage.classList.remove("hidden");
+        
+        // Close modal and update UI
+        setTimeout(() => {
+          loginModal.classList.add("hidden");
+          loginForm.reset();
+          checkAuthStatus();
+        }, 1000);
+      } else {
+        const result = await response.json();
+        loginMessage.textContent = result.detail || "Login failed";
+        loginMessage.className = "error";
+        loginMessage.classList.remove("hidden");
+      }
+    } catch (error) {
+      loginMessage.textContent = "Error logging in. Please try again.";
+      loginMessage.className = "error";
+      loginMessage.classList.remove("hidden");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  // Handle logout
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", { method: "POST" });
+      if (response.ok) {
+        isAuthenticated = false;
+        currentUser = null;
+        updateUI();
+        userMenu.classList.add("hidden");
+      }
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+  });
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -21,21 +153,26 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
-        const participantsHTML =
-          details.participants.length > 0
-            ? `<div class="participants-section">
-              <h5>Participants:</h5>
-              <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
-              </ul>
-            </div>`
-            : `<p><em>No participants yet</em></p>`;
+        // Create participants HTML with delete buttons (only for authenticated teachers)
+        let participantsHTML;
+        if (details.participants.length > 0) {
+          const participantItems = details.participants
+            .map((email) => {
+              const deleteBtn = isAuthenticated
+                ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                : "";
+              return `<li><span class="participant-email">${email}</span>${deleteBtn}</li>`;
+            })
+            .join("");
+          participantsHTML = `<div class="participants-section">
+            <h5>Participants:</h5>
+            <ul class="participants-list">
+              ${participantItems}
+            </ul>
+          </div>`;
+        } else {
+          participantsHTML = `<p><em>No participants yet</em></p>`;
+        }
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
@@ -69,6 +206,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    event.preventDefault();
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -88,8 +226,6 @@ document.addEventListener("DOMContentLoaded", () => {
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -97,8 +233,6 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
       setTimeout(() => {
         messageDiv.classList.add("hidden");
       }, 5000);
@@ -133,8 +267,6 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -142,8 +274,6 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
       setTimeout(() => {
         messageDiv.classList.add("hidden");
       }, 5000);
@@ -156,5 +286,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  checkAuthStatus();
 });

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -48,9 +48,14 @@ document.addEventListener("DOMContentLoaded", () => {
     fetchActivities();
   }
 
-  // Toggle user menu
+  // Toggle user menu or open login modal when not authenticated
   userBtn.addEventListener("click", () => {
-    userMenu.classList.toggle("hidden");
+    if (isAuthenticated) {
+      userMenu.classList.toggle("hidden");
+    } else {
+      loginModal.classList.remove("hidden");
+      userMenu.classList.add("hidden");
+    }
   });
 
   // Close user menu when clicking outside
@@ -60,12 +65,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  // Open login modal when not authenticated
-  userBtn.addEventListener("dblclick", () => {
-    if (!isAuthenticated) {
-      loginModal.classList.remove("hidden");
-    }
-  });
+  // Remove double-click login behavior; normal click opens login modal now
 
   // Close modal when clicking close button
   closeBtn.addEventListener("click", () => {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,9 +8,40 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-content">
+        <div class="header-title">
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <div class="user-section">
+          <button id="user-btn" class="user-btn">👤 Login</button>
+          <div id="user-menu" class="user-menu hidden">
+            <div id="user-info"></div>
+            <button id="logout-btn" class="logout-btn hidden">Logout</button>
+          </div>
+        </div>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="close-btn">&times;</span>
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="Enter your username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter your password" />
+          </div>
+          <button type="submit" class="login-submit-btn">Login</button>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -21,8 +52,8 @@
         </div>
       </section>
 
-      <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+      <section id="signup-container" class="hidden">
+        <h3>Register Student for Activity</h3>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -35,7 +66,7 @@
               <!-- Activity options will be loaded here -->
             </select>
           </div>
-          <button type="submit">Sign Up</button>
+          <button type="submit">Register Student</button>
         </form>
         <div id="message" class="hidden"></div>
       </section>
@@ -48,3 +79,4 @@
     <script src="app.js"></script>
   </body>
 </html>
+

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -17,16 +17,131 @@ body {
 
 header {
   text-align: center;
-  padding: 20px 0;
+  padding: 20px;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
 }
 
-header h1 {
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+}
+
+.header-title {
+  flex: 1;
+}
+
+.header-title h1 {
   margin-bottom: 10px;
 }
+
+.user-section {
+  position: relative;
+}
+
+.user-btn {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 2px solid white;
+  padding: 8px 12px;
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.user-btn:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.user-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: white;
+  color: #333;
+  border-radius: 5px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  padding: 10px;
+  margin-top: 5px;
+  min-width: 150px;
+  z-index: 100;
+}
+
+.user-menu p {
+  margin: 10px 0;
+  padding: 0 5px;
+}
+
+.logout-btn {
+  background-color: #c62828;
+  width: 100%;
+  margin-top: 10px;
+}
+
+.logout-btn:hover {
+  background-color: #ad1457;
+}
+
+/* Login Modal */
+.modal {
+  position: fixed;
+  z-index: 200;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  max-width: 400px;
+  width: 90%;
+  position: relative;
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+}
+
+.close-btn {
+  color: #999;
+  position: absolute;
+  right: 15px;
+  top: 10px;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.close-btn:hover {
+  color: #000;
+}
+
+.login-submit-btn {
+  width: 100%;
+  background-color: #1a237e;
+}
+
+#login-message {
+  margin-top: 15px;
+}
+
+
 
 main {
   display: flex;

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,16 @@
+{
+  "teachers": [
+    {
+      "username": "ms_smith",
+      "password": "Mergington2026!"
+    },
+    {
+      "username": "mr_johnson",
+      "password": "TeachCode123!"
+    },
+    {
+      "username": "ms_garcia",
+      "password": "SchoolPride2026!"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Implements Admin Mode to prevent students from removing each other from activities. Only authenticated teachers can now register or unregister students.

## Changes
- Add teacher authentication system with session management
- Create `/auth/login`, `/auth/logout`, and `/auth/status` endpoints
- Protect activity signup/unregister endpoints to require teacher authentication
- Add `teachers.json` with sample teacher credentials:
  - `ms_smith` / `Mergington2026!`
  - `mr_johnson` / `TeachCode123!`
  - `ms_garcia` / `SchoolPride2026!`
- Add login modal to frontend with username/password form
- Add user menu in header showing authentication status
- Only show delete/register buttons when logged in as teacher
- Students can view activities and participants but cannot make changes

## How to Test
1. Visit the page - you should see activities and participants, but no delete buttons
2. Click the user icon (👤) in the top right
3. Use any of the teacher credentials above to login
4. After login, the "Register Student" form appears and delete buttons appear on participants
5. Click logout to return to student view

## Resolves
Closes #5